### PR TITLE
refactor: Remove obsolete browser entry from agents registry (#9)

### DIFF
--- a/agents/registry.json
+++ b/agents/registry.json
@@ -14,7 +14,6 @@
           "exec",
           "bash",
           "process",
-          "browser",
           "cron",
           "session_status",
           "sessions_list",


### PR DESCRIPTION
Closes #9

## Changes Summary
- GitHub Issue: #9
- Commits: 1 commit
- Files Changed: 1 file (0 added, 1 modified, 0 deleted)
- Primary Change Type: refactor
- Affected Areas: `agents/` (registry source)

# Pull Request

## Context & Purpose

- Addresses **#9: Security audit follow-up: remove stale browser plugin entry**. The security assessment flagged a stale `browser` plugin entry in pack source `agents/registry.json` as the only clear repo-owned fix from that audit.
- This change removes that obsolete entry so the pack no longer advertises or sources a browser plugin that is no longer required.

## What changed

- **Modified:** `agents/registry.json` — removed the `browser` plugin entry (one line deleted).
- No behavior changes to bundles, runtime fragments, or scripts in this commit; scope is limited to the registry source as requested in the issue.

## How to test

Verification run locally before opening this PR:

```bash
bash -n scripts/*.sh
jq empty agents/registry.json bundles/*.json runtime/*.json runtime/config-fragments/*.json
```

Reviewers can confirm `browser` is absent from `agents/registry.json` and that generated pack workflows (if any) do not need that entry.

## Checklist

- [x] No secrets/tokens/private paths were committed (especially `.env` or credential-bearing output)
- [ ] Docs updated if user workflow changed (not required for this registry-only removal)
- [x] Changes are scoped and easy to review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a single stale tool entry from `agents/registry.json` with no other code changes or references found.
> 
> **Overview**
> Removes the obsolete `browser` entry from the allowed tools list in `agents/registry.json`, so the agent registry no longer advertises/supports that plugin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f1ba323025c70825127dfe9209b58092f5c50dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->